### PR TITLE
feat: enrich CV content and refine the print/PDF layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -618,40 +618,86 @@ p {
 	}
 }
 
-/* Download CV button */
-.print-cv {
-	margin-top: 1.5em;
-	display: inline-flex;
-	align-items: center;
-	gap: 0.5em;
-	font-family: var(--font-raleway);
-	font-size: 0.85em;
-	font-weight: 600;
-	letter-spacing: 0.08em;
-	text-transform: uppercase;
-	color: #fff;
-	background-color: var(--color-blue);
-	border: none;
-	border-radius: 999px;
-	padding: 0.7em 1.4em;
+/* Download-as-PDF icon, sits inline with the social links */
+.networks .print-cv-icon a {
 	cursor: pointer;
-	box-shadow: 0 2px 8px rgba(63, 159, 219, 0.35);
-	transition:
-		background-color var(--ease),
-		box-shadow var(--ease),
-		transform var(--ease);
+	color: var(--color-blue);
+	transition: color var(--ease);
 }
 
-.print-cv:hover,
-.print-cv:focus-visible {
-	background-color: var(--color-blue-strong);
-	box-shadow: 0 4px 14px rgba(63, 159, 219, 0.45);
-	transform: translateY(-2px);
+.networks .print-cv-icon a:hover,
+.networks .print-cv-icon a:focus-visible {
+	color: var(--color-blue-strong);
 	outline: none;
 }
 
-.print-cv .fas {
-	font-size: 1.1em;
+/* Repo-driven CV sections (skills, education, languages, talks) */
+.cv-block {
+	position: relative;
+	z-index: 1;
+	background-color: #fff;
+	padding: 2.5em 1em;
+}
+
+.cv-block .content-section {
+	padding: 0;
+}
+
+.skills .content-section__content {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.6em;
+	margin: 0;
+	padding: 0;
+}
+
+.skills .content-section__content li {
+	list-style: none;
+	font-family: var(--font-raleway);
+	font-size: 0.8em;
+	font-weight: 600;
+	letter-spacing: 0.03em;
+	background-color: rgba(63, 159, 219, 0.1);
+	color: var(--color-blue-strong);
+	padding: 0.45em 1em;
+	border-radius: 999px;
+}
+
+.languages .content-section__content,
+.talks .content-section__content {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.languages .content-section__content li,
+.talks .content-section__content li {
+	list-style: none;
+	position: relative;
+	margin: 0.5em 0;
+	padding-left: 1.3em;
+	line-height: 1.55;
+}
+
+.languages .content-section__content li::before,
+.talks .content-section__content li::before {
+	content: "\25B9";
+	position: absolute;
+	left: 0;
+	color: var(--color-blue);
+}
+
+.talks .content-section__content a {
+	color: var(--color-blue);
+}
+
+.education .content-section__content p {
+	margin: 0.2em 0;
+}
+
+.education .content-section__content p:last-child {
+	color: var(--color-muted);
+	font-size: 0.95em;
 }
 
 /*
@@ -680,7 +726,7 @@ p {
 	}
 
 	/* Hide on-screen-only chrome and decoration */
-	.print-cv,
+	.print-cv-icon,
 	.articles-outer,
 	.me-outro,
 	.time-line__item .fas,
@@ -691,6 +737,41 @@ p {
 	.grey-bg::before,
 	.blue-bg::before {
 		display: none !important;
+	}
+
+	/* Repo-driven CV sections print compactly */
+	.cv-block {
+		padding: 0 0 0.7em !important;
+		background: none !important;
+	}
+
+	.education,
+	.languages,
+	.talks {
+		break-inside: avoid;
+		page-break-inside: avoid;
+	}
+
+	.skills .content-section__content {
+		gap: 0.35em !important;
+	}
+
+	.skills .content-section__content li {
+		font-size: 0.78em !important;
+		padding: 0.15em 0.6em !important;
+		color: #000 !important;
+		background-color: rgba(63, 159, 219, 0.08) !important;
+		border: 0.5pt solid var(--color-border);
+	}
+
+	.languages .content-section__content li,
+	.talks .content-section__content li {
+		margin: 0.2em 0 !important;
+		font-size: 0.92em;
+	}
+
+	.education .content-section__content p:last-child {
+		font-size: 0.9em;
 	}
 
 	.aims,

--- a/assets/style.css
+++ b/assets/style.css
@@ -656,30 +656,36 @@ p {
 
 /*
  * Print / "Save as PDF" styles.
- * Turns the page into a clean, single-column CV: expands the collapsed
- * timeline entries, drops the decorative skewed backgrounds, hides on-screen
- * chrome and fixes colors so nothing prints white-on-white.
+ * Reflow the page into a clean, single-column resume: a compact header with
+ * contact links, clearly labelled sections, and one readable block per role.
+ * Drops the decorative backgrounds, the blog, the footer and all on-screen
+ * chrome, and fixes colors so nothing prints white-on-white.
  */
 @media print {
 	@page {
-		margin: 1.5cm;
+		margin: 1.2cm 1.4cm;
 	}
 
 	body {
-		font-size: 12px;
+		font-size: 10.5pt;
+		line-height: 1.4;
 		color: #000;
 		background: #fff;
+		-webkit-print-color-adjust: exact;
+		print-color-adjust: exact;
 	}
 
-	/* Hide on-screen-only chrome */
+	p {
+		font-weight: 400;
+	}
+
+	/* Hide on-screen-only chrome and decoration */
 	.print-cv,
 	.articles-outer,
 	.me-outro,
-	.time-line__item .fas {
-		display: none !important;
-	}
-
-	/* Remove the rotated colored backgrounds and any clipping */
+	.time-line__item .fas,
+	.time-line__item::before,
+	.time-line__item::after,
 	.aims::before,
 	.resume::before,
 	.grey-bg::before,
@@ -695,63 +701,177 @@ p {
 		overflow: visible !important;
 	}
 
+	/* ---- Shared section headings ---- */
+	.content-section__title,
+	.time-line::before {
+		display: block !important;
+		font-family: var(--font-open-sans) !important;
+		font-size: 1.05em !important;
+		font-weight: 700 !important;
+		font-style: normal !important;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: #000 !important;
+		border-bottom: 1.5px solid #000;
+		padding: 0 0 0.2em !important;
+		margin: 0 0 0.6em !important;
+		page-break-after: avoid;
+	}
+
+	/* The About section has an empty title — don't print a stray heading bar */
+	.content-section__title:empty {
+		display: none !important;
+	}
+
+	/* ---- Header ---- */
+	.site header {
+		padding: 0 !important;
+	}
+
+	.me-intro {
+		padding: 0 0 0.8em !important;
+		margin-bottom: 0.8em;
+		border-bottom: 2px solid #000;
+		justify-content: flex-start !important;
+		flex-wrap: nowrap !important;
+		gap: 1.2em;
+		page-break-after: avoid;
+	}
+
+	.me-intro .picture {
+		flex: 0 0 auto !important;
+		padding: 0 !important;
+	}
+
+	.me-intro .picture img {
+		width: 96px !important;
+		height: 96px !important;
+		object-fit: cover;
+	}
+
+	.me-intro .content {
+		flex: 1 1 auto !important;
+		text-align: left !important;
+	}
+
+	.me-intro .content h1 {
+		font-size: 1.7em !important;
+		margin: 0 !important;
+	}
+
+	.me-intro .content h3 {
+		font-size: 1em !important;
+		font-style: italic;
+		color: var(--color-muted) !important;
+		margin: 0.15em 0 0.5em !important;
+	}
+
+	/* Contact links: show the actual URL, not just an icon */
+	.networks {
+		display: block !important;
+		justify-content: flex-start !important;
+	}
+
+	.networks .network-link {
+		padding: 0 !important;
+		margin: 0 0 0.1em;
+	}
+
+	.networks .network-link a {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5em;
+		color: #000 !important;
+		font-size: 0.82em !important;
+	}
+
+	.networks .network-link a .fab {
+		flex: 0 0 1.1em;
+		text-align: center;
+	}
+
+	.networks .network-link a::after {
+		content: attr(href);
+		font-family: var(--font-lato);
+		word-break: break-all;
+	}
+
+	/* ---- About / Aims sections ---- */
+	.resume {
+		padding: 0 0 0.8em !important;
+	}
+
+	.aims {
+		padding: 0 0 0.8em !important;
+		margin-bottom: 0.8em !important;
+	}
+
 	.aims .content-section__title {
 		color: #000 !important;
 	}
 
-	/* Tighten section spacing for paper */
-	.resume {
-		padding: 1.5em 0 1em !important;
+	.content-section__content p {
+		margin: 0.3em 0 !important;
 	}
 
-	.aims {
-		padding: 1.5em 0 1em !important;
-		margin-bottom: 0 !important;
+	.aims .content-section__content {
+		padding-left: 1.1em;
 	}
 
-	.me-intro {
-		padding: 0 0 1.5em !important;
-		justify-content: flex-start !important;
-		page-break-after: avoid;
+	.aims .content-section__content li {
+		margin: 0.2em 0;
 	}
 
-	.me-intro .picture img {
-		width: 120px !important;
-		-webkit-print-color-adjust: exact;
-		print-color-adjust: exact;
-	}
-
-	.networks .network-link a {
-		color: #000 !important;
-		font-size: 1.5em !important;
-	}
-
-	/* Expand every experience entry so the full history is on the page */
+	/* ---- Experience ---- */
 	.time-line {
-		padding: 1em 0 !important;
+		padding: 0 !important;
 		display: block !important;
 	}
 
 	.time-line::before {
-		display: none !important;
+		content: "Experience";
+		position: static !important;
+		height: auto !important;
+		width: auto !important;
+		background: none !important;
 	}
 
 	.time-line__item {
 		width: 100% !important;
 		left: 0 !important;
-		margin: 0 0 1em !important;
-		padding: 0.5em 0 1em !important;
+		margin: 0 0 0.7em !important;
+		padding: 0 !important;
+		background: none !important;
 		box-shadow: none !important;
 		border: none !important;
-		border-bottom: 1px solid var(--color-border) !important;
 		border-radius: 0 !important;
 		page-break-inside: avoid;
 		break-inside: avoid;
 	}
 
-	.time-line__item::before,
-	.time-line__item::after {
-		display: none !important;
+	.time-line__item .label {
+		float: right;
+		position: static !important;
+		padding: 0 !important;
+		background: none !important;
+		color: var(--color-muted) !important;
+		font-size: 0.85em !important;
+		font-weight: 600;
+	}
+
+	.time-line__item .title {
+		font-size: 1.02em !important;
+		font-weight: 700 !important;
+		color: #000 !important;
+		margin: 0 !important;
+		page-break-after: avoid;
+	}
+
+	.time-line__item .subtitle {
+		font-size: 0.85em !important;
+		font-style: italic;
+		color: var(--color-muted) !important;
+		margin: 0.05em 0 0.35em !important;
 	}
 
 	.time-line__item .description {
@@ -760,19 +880,10 @@ p {
 		overflow: visible !important;
 	}
 
-	.time-line__item .label {
-		position: static !important;
-		display: inline-block;
-		padding: 0 !important;
-		background: none !important;
-		color: var(--color-muted) !important;
-		font-style: italic;
-	}
-
-	/* Avoid orphaned headings */
-	.content-section__title,
-	.time-line__item .title {
-		page-break-after: avoid;
+	.time-line__item .description p {
+		margin: 0.25em 0 !important;
+		font-size: 0.92em;
+		line-height: 1.4;
 	}
 
 	a {

--- a/components/me-intro.js
+++ b/components/me-intro.js
@@ -36,16 +36,19 @@ window.addEventListener("WebComponentsReady", function () {
 						return `<network-link network="${encodeJSON(network)}"></network-link>`;
 					})
 					.join("")}
+              <section class="network-link print-cv-icon">
+                <a href="#" role="button" title="Download CV as PDF" aria-label="Download CV as PDF">
+                  <i class="fas fa-file-pdf"></i>
+                </a>
+              </section>
             </section>
-            <button type="button" class="print-cv" title="Save this page as a PDF">
-              <i class="fas fa-file-pdf"></i> Download CV
-            </button>
           </section>
         </section>
       `;
 		},
 		events: {
-			"click .print-cv": function () {
+			"click .print-cv-icon": function (event) {
+				event.preventDefault();
 				window.print();
 			},
 		},

--- a/components/site.js
+++ b/components/site.js
@@ -5,6 +5,47 @@ import "./content-section.js";
 import "./time-line.js";
 import "./articles.js";
 
+// Static CV content kept in the repo (not in the gist) so the downloaded
+// CV / print view matches the full written resume.
+var CV_SKILLS = [
+	"Golang",
+	"Docker",
+	"Kubernetes",
+	"Javascript",
+	"React",
+	"Vue.js",
+	"State management libraries",
+	"Web Components",
+	"Ruby",
+	"Amazon Web Services",
+	"HTML / CSS",
+	"Node.js",
+	"MySQL",
+	"MongoDB",
+	"PostgreSQL",
+	"Linux",
+	"Bash",
+	"Apache",
+	"Nginx",
+	"Git",
+	"Front-end automation tools",
+];
+
+var CV_EDUCATION = [
+	"<strong>Telecommunications Engineer</strong>",
+	"Universidad Cat&oacute;lica Andr&eacute;s Bello &mdash; 2009",
+];
+
+var CV_LANGUAGES = [
+	"<strong>English</strong>: written (advanced), verbal (advanced)",
+	"<strong>Spanish</strong>: native",
+];
+
+var CV_TALKS = [
+	"<strong>Noders JS</strong> &mdash; Santiago, Chile (January 2019). React Hooks.",
+	'<strong>La Plata JS</strong> &mdash; La Plata, Argentina (December 2018). The current state of web components in the browser and how we can use them today. <a href="http://slides.com/highercomve/web-components" target="_blank" rel="noopener">slides</a>',
+];
+
 window.addEventListener("WebComponentsReady", function () {
 	var Site = {
 		html_url: null,
@@ -31,6 +72,10 @@ window.addEventListener("WebComponentsReady", function () {
 				get(this, "content.about_me.content", []),
 			);
 			var aimsContent = encodeJSON(get(this, "content.aims.content", []));
+			var skills = encodeJSON(CV_SKILLS);
+			var education = encodeJSON(CV_EDUCATION);
+			var languages = encodeJSON(CV_LANGUAGES);
+			var talks = encodeJSON(CV_TALKS);
 			return `
         <section class="site">
 			<header>
@@ -42,7 +87,19 @@ window.addEventListener("WebComponentsReady", function () {
 			<section class="aims">
 				<content-section title="${get(this, "content.aims.title")}" wrapper="${get(this, "content.aims.wrapper")}" content="${aimsContent}"></content-section>
 			</section>
+			<section class="cv-block skills">
+				<content-section title="Technical skills" wrapper="li" content="${skills}"></content-section>
+			</section>
 			<time-line gist="${this.gist}"></time-line>
+			<section class="cv-block education">
+				<content-section title="Education" wrapper="p" content="${education}"></content-section>
+			</section>
+			<section class="cv-block languages">
+				<content-section title="Languages" wrapper="li" content="${languages}"></content-section>
+			</section>
+			<section class="cv-block talks">
+				<content-section title="Talks" wrapper="li" content="${talks}"></content-section>
+			</section>
 			<latest-articles></latest-articles>
           	<me-outro name="${get(this, "content.name")}" url="${this.html_url}" ></me-outro>
         </section>

--- a/components/time-line.js
+++ b/components/time-line.js
@@ -1,5 +1,26 @@
 import { getGist } from "../js/utils.js";
 
+// Teaching roles kept in the repo (not in the gist), appended after the
+// experience pulled from the gist so the CV matches the full written resume.
+var EXTRA_ITEMS = [
+	{
+		title: "Ruby Teacher - Escuelaweb",
+		label: "2011 - 2015",
+		subtitle: "escuelaweb.net - Ruby",
+		description: [
+			"Taught how to build web applications with Ruby — using the full power of Ruby on Rails, or building APIs with the flexibility of Sinatra.",
+		],
+	},
+	{
+		title: "HTML / CSS / JavaScript Teacher - Escuelaweb",
+		label: "2009 - 2015",
+		subtitle: "escuelaweb.net - HTML / CSS / JavaScript",
+		description: [
+			"Taught modern front-end development: Yeoman, Grunt, CSS preprocessors, HTML5, CSS3, JavaScript client frameworks (AngularJS), jQuery, and jQuery Mobile.",
+		],
+	},
+];
+
 window.addEventListener("WebComponentsReady", function () {
 	var Component = {
 		timeline: [],
@@ -14,7 +35,7 @@ window.addEventListener("WebComponentsReady", function () {
 					JSON.parse(response.files["experience.json"].content),
 				)
 				.then((response) => {
-					this.timeline = response.items;
+					this.timeline = (response.items || []).concat(EXTRA_ITEMS);
 					this.updateComponent();
 				});
 		},


### PR DESCRIPTION
Builds on the merged PDF-export feature (#2) with a proper CV layout and the full written-resume content.

## Print / PDF layout reworked into a real resume
- Compact header (photo + name + tagline) with contact links that print their **actual URLs** instead of bare icons.
- Uppercase section headings with rules; an injected **"Experience"** heading (the timeline never had one).
- Each role prints as **title + date on one line**, company/stack as a subtitle, and readable description bullets, with `break-inside: avoid` so jobs don't split across pages.
- Empty headings, the blog, the footer and the decorative skewed backgrounds are hidden.

## New content (shown on the site **and** in the PDF)
Kept in the repo (not the gist), per preference:
- **Technical skills** — full list, chips on screen / compact bordered list in print.
- **Education** — Telecommunications Engineer, Universidad Católica Andrés Bello (2009).
- **Languages** — English (advanced) / Spanish (native).
- **Talks** — Noders JS (React Hooks, 2019) and La Plata JS (web components, with slides link).
- **Two Escuelaweb teaching roles** appended to the experience timeline.

No phone/email/contact details are included, by request.

## Download control
- Replaced the large "Download CV" button with a compact **PDF icon inline with the social links** (hidden from the PDF itself).

### Source of the new content
- `components/site.js` — `CV_SKILLS / CV_EDUCATION / CV_LANGUAGES / CV_TALKS`
- `components/time-line.js` — `EXTRA_ITEMS` (teaching roles)
- `assets/style.css` — on-screen styling for the new sections + the reworked `@media print` block

> Note: not rendered/verified in a browser from the dev environment (no headless browser available) — worth a quick print-preview check of skills-chip wrapping and the PDF icon sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KS9WUtF9MmFbJGwdxtMUEJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KS9WUtF9MmFbJGwdxtMUEJ)_